### PR TITLE
ASM-3303 ASM to discover and inventory N3000 and N4000 switches and show them under Resources page

### DIFF
--- a/lib/puppet/util/network_device/dell_powerconnect/device.rb
+++ b/lib/puppet/util/network_device/dell_powerconnect/device.rb
@@ -15,6 +15,7 @@ class Puppet::Util::NetworkDevice::Dell_powerconnect::Device < Puppet::Util::Net
   def initialize(url, options = {})
     super(url)
     @enable_password = options[:enable_password] || parse_enable(@url.query)
+    @enable_password ||= URI.decode(asm_decrypt(@url.password))
     @initialized = false
     transport.default_prompt = /[#>]\s?\z/n
   end


### PR DESCRIPTION
Powerconnect discovery anticipates enabled password in the input device configuration file. Added normal password as enable passed in case the value is not pased