### PR TITLE
ASM-3398: Use the new credential_id system

### DIFF
--- a/lib/puppet/util/network_device/base_powerconnect.rb
+++ b/lib/puppet/util/network_device/base_powerconnect.rb
@@ -13,6 +13,7 @@ class Puppet::Util::NetworkDevice::Base_powerconnect
   attr_accessor :url, :transport, :crypt
   def initialize(url)
     @url = URI.parse(url)
+    @query = Hash.new([])
     @query = CGI.parse(@url.query) if @url.query
 
     require "puppet/util/network_device/transport_powerconnect/#{@url.scheme}"
@@ -32,6 +33,17 @@ class Puppet::Util::NetworkDevice::Base_powerconnect
         @transport.user = URI.decode(@url.user)
         @transport.password = URI.decode(asm_decrypt(@url.password))
       end
+    end
+
+    override_using_credential_id
+  end
+
+  def override_using_credential_id
+    if id = @query.fetch('credential_id', []).first
+      require 'asm/cipher'
+      cred = ASM::Cipher.decrypt_credential(id)
+      @transport.user = cred.username
+      @transport.password = cred.password
     end
   end
 

--- a/lib/puppet/util/network_device/dell_powerconnect/device.rb
+++ b/lib/puppet/util/network_device/dell_powerconnect/device.rb
@@ -15,7 +15,7 @@ class Puppet::Util::NetworkDevice::Dell_powerconnect::Device < Puppet::Util::Net
   def initialize(url, options = {})
     super(url)
     @enable_password = options[:enable_password] || parse_enable(@url.query)
-    @enable_password ||= URI.decode(asm_decrypt(@url.password))
+    @enable_password ||= @transport.password
     @initialized = false
     transport.default_prompt = /[#>]\s?\z/n
   end
@@ -33,13 +33,12 @@ class Puppet::Util::NetworkDevice::Dell_powerconnect::Device < Puppet::Util::Net
 
   def login
     return if transport.handles_login?
-    if @url.user != ''
-      transport.command(@url.user, {:prompt => /^Password:/, :noop => false})
+    if @transport.user != ''
+      transport.command(@transport.user, {:prompt => /^Password:/, :noop => false})
     else
       transport.expect(/^Password:/)
     end
-	password = URI.decode(asm_decrypt(@url.password))
-    transport.command(password, :noop => false)
+    transport.command(@transport.password, :noop => false)
   end
 
   def enable


### PR DESCRIPTION
Small refactors needed since overiding sets @transport.user and
@transport.password we use that everywhere else instead of re-decoding
user/password all over the show