### PR TITLE
ASM-3830 Rack switches not getting configured when PowerConnect N in inventory

### DIFF
--- a/lib/puppet/util/network_device/dell_powerconnect/possible_facts/base.rb
+++ b/lib/puppet/util/network_device/dell_powerconnect/possible_facts/base.rb
@@ -279,8 +279,10 @@ module Puppet::Util::NetworkDevice::Dell_powerconnect::PossibleFacts::Base
         txt.scan(/^\d+\s+(\S+)\s+(\S+)\s+(\S+)/) do |arr|
           remotedevices[arr[0]] = arr[2]
         end
-        res["remotedeviceinfo"] = remotedevices.to_json
-        res
+        # Commenting remote hash information as mac-address information is
+        # listing from other switches via inter-switch link
+        #res["remotedeviceinfo"] = remotedevices.to_json
+        res["remotedeviceinfo"] = {'name' => 'value'}.to_json
       end
       cmd 'show mac address-table'
     end


### PR DESCRIPTION
PowerConnect switch discovery code is using mac-address table information for remote-host fact. It is observed that mac-address table is listing the mac address of equipment connect to other switches via upstream port-channel.

These switches are not used for end to end deployment with ASM, For now removing the remote host information, till a better solution is identified.