### PR TITLE
RemoteDeviceInfo fact fix

### DIFF
--- a/lib/puppet_x/dell_powerconnect/possible_facts/base.rb
+++ b/lib/puppet_x/dell_powerconnect/possible_facts/base.rb
@@ -279,7 +279,7 @@ module PuppetX::DellPowerconnect::PossibleFacts::Base
           #Line will be something like "Te1/0/5   29      AA:BB:CC:DD:EE:FF   eth0                name"
           next if i < 5  # Skip the first 5 lines (headers)
           tokens = line.scan(/\S+/)
-          next unless tokens.size == 5
+          next unless tokens.size > 3
 
           interface = tokens[0]
           location = tokens[3]
@@ -304,7 +304,7 @@ module PuppetX::DellPowerconnect::PossibleFacts::Base
         txt.split(/\n+/).each do |line|
           #Line will be something like "Te1/0/5   29      AA:BB:CC:DD:EE:FF   eth0                name"
           tokens = line.scan(/\S+/)
-          next unless tokens.size == 5
+          next unless tokens.size > 3
 
           port = tokens[0]
           mac = tokens[2]


### PR DESCRIPTION
When checking LLDP info, check for at least 4 fields as not all
columns are required
```
env12ToR1#show lldp remote-device all

LLDP Remote Device Summary

Local
Interface RemID   Chassis ID          Port ID           System Name
--------- ------- ------------------- ----------------- -----------------
Te1/0/2   13      00:0A:F7:06:7C:A0   00:0A:F7:06:7C:A0
Te1/0/13  37      00:0A:F7:4F:D4:40   00:0A:F7:4F:D4:40
Te1/0/14  38      00:0A:F7:4F:D4:44   00:0A:F7:4F:D4:44
Te1/0/17  28      F8:B1:56:76:BA:8D   TenGigabitEthernet 0/11  Dell
Te1/0/18  30      F8:B1:56:76:BB:DD   TenGigabitEthernet 0/12  Dell
Te1/0/25  15      00:0A:F7:23:AE:70   00:0A:F7:23:AE:70
Te1/0/29  18      00:10:18:E7:E4:A0   00:10:18:E7:E4:A0
Te1/0/33  257     00:0A:F7:71:78:D0   00:0A:F7:71:78:D0
Te1/0/48  27      00:01:E8:8B:13:E2   TenGigabitEthernet 1/22
Fo1/0/1   19      F8:B1:56:54:63:9D   Fo1/0/1             env12ToR2
```