### PR TITLE
Add vlan_information fact

### DIFF
--- a/lib/puppet_x/dell_powerconnect/possible_facts/base.rb
+++ b/lib/puppet_x/dell_powerconnect/possible_facts/base.rb
@@ -327,5 +327,13 @@ module PuppetX::DellPowerconnect::PossibleFacts::Base
       cmd 'show running-config'
     end
 
+    base.register_param 'vlan_information' do
+      match do |txt|
+        base.vlan_information(txt).to_json
+      end
+      cmd "show interface status"
+    end
+
   end
+
 end

--- a/spec/fixtures/unit/puppet_x/dell_powerconnect/show_interface_status.out
+++ b/spec/fixtures/unit/puppet_x/dell_powerconnect/show_interface_status.out
@@ -1,0 +1,67 @@
+env12ToR1#show interfaces status
+
+Port      Description     Duplex Speed   Neg  Link   Flow  M  VLAN
+                                              State  Ctrl
+--------- --------------- ------ ------- ---- ------ ----- -- -------------------
+Te1/0/1                   Full   10000   Off  Down   Off   A  1
+Te1/0/2   Mgmt Host       Full   10000   Off  Up     Off   T  (1),2-4096
+Te1/0/3                   Full   10000   Off  Down   Off   A  1
+Te1/0/4                   Full   10000   Off  Down   Off   A  1
+Te1/0/5   EQL Array       Full   10000   Off  Down   Off   A  16
+Te1/0/6   EQL Array       Full   10000   Off  Down   Off   A  16
+Te1/0/7                   Full   10000   Off  Down   Off   A  1
+Te1/0/8                   Full   10000   Off  Down   Off   A  1
+Te1/0/9                   Full   10000   Off  Up     Off   G  (25),1,29
+Te1/0/10                  Full   10000   Off  Up     Off   A  1
+Te1/0/11                  Full   10000   Off  Up     Off   A  1
+Te1/0/12                  Full   10000   Off  Up     Off   A  1
+Te1/0/13                  Full   10000   Off  Up     Off   G  (25),1,20,23-24,28
+Te1/0/14                  Full   10000   Off  Up     Off   G  (25),1,20,23-24
+Te1/0/15                  Full   10000   Off  Up     Off   G  (25),1,20,23-24
+Te1/0/16                  Full   10000   Off  Up     Off   G  (25),1,20,23-24
+Te1/0/17  H1RRD42 PO 11   Full   10000   Off  Up     Off   G  (1),16,18,20,
+                                                              22-23,25,28
+Te1/0/18  H1RRD42 PO 12   Full   10000   Off  Up     Off   G  (1),16,18,20,
+                                                              22-23,25,28
+Te1/0/19                  Full   10000   Off  Down   Off   A  1
+Te1/0/20                  Full   10000   Off  Down   Off   G  (25),1,20,23-24,28
+Te1/0/21                  Full   10000   Off  Down   Off   A  1
+Te1/0/22                  Full   10000   Off  Down   Off   A  1
+Te1/0/23                  Full   10000   Off  Down   Off   A  1
+Te1/0/24                  Full   10000   Off  Down   Off   A  1
+Te1/0/25                  Full   10000   Off  Up     Off   G  (25),1,20,23,28
+Te1/0/26                  Full   10000   Off  Up     Off   A  1
+Te1/0/27                  Full   10000   Off  Down   Off   A  1
+Te1/0/28                  Full   10000   Off  Down   Off   A  1
+Te1/0/29                  Full   10000   Off  Up     Off   G  (18),1,20,22-24,28
+Te1/0/30                  Full   10000   Off  Down   Off   A  1
+Te1/0/31                  Full   10000   Off  Down   Off   G  (25),1,20,23-24,29
+Te1/0/32                  Full   10000   Off  Down   Off   A  1
+Te1/0/33                  Full   10000   Off  Up     Off   G  (18),1,16,20,23,
+                                                              25,28
+Te1/0/34                  Full   10000   Off  Down   Off   G  (25),1,16,20,23,28
+Te1/0/35                  Full   10000   Off  Down   Off   G  (25),1,16,20,23,28
+Te1/0/36                  Full   10000   Off  Down   Off   G  (25),1,16,20,23,28
+Te1/0/37                  Full   10000   Off  Down   Off   A  1
+Te1/0/38                  Full   10000   Off  Down   Off   A  1
+Te1/0/39                  Full   10000   Off  Down   Off   G  (25),20,23,28
+Te1/0/40                  Full   10000   Off  Down   Off   A  1
+Te1/0/41                  Full   10000   Off  Down   Off   A  1
+Te1/0/42                  Full   10000   Off  Down   Off   A  1
+Te1/0/43                  Full   10000   Off  Down   Off   A  1
+Te1/0/44                  Full   10000   Off  Down   Off   A  1
+Te1/0/45                  Full   10000   Off  Down   Off   A  1
+Te1/0/46                  Full   10000   Off  Down   Off   A  1
+Te1/0/47                  Full   10000   Off  Down   Off   A  1
+Te1/0/48  MLAG-Partner-li Full   10000   Off  Up     Off   T  (1),2-15,17-4093
+Fo1/0/1   MLAG-Peer-Link  Full   40000   Auto Up     Off   T  (1),2-4096
+Fo1/0/2                   Full   40000   Off  Down   Off   A  1
+Te1/0/49                  N/A    N/A     N/A  Detach N/A
+Te1/0/50                  N/A    N/A     N/A  Detach N/A
+Te1/0/51                  N/A    N/A     N/A  Detach N/A
+Te1/0/52                  N/A    N/A     N/A  Detach N/A
+Te1/0/53                  N/A    N/A     N/A  Detach N/A
+Te1/0/54                  N/A    N/A     N/A  Detach N/A
+Te1/0/55                  N/A    N/A     N/A  Detach N/A
+Te1/0/56                  N/A    N/A     N/A  Detach N/A
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,10 @@ require 'puppet/util/network_device/transport/ssh'
 
 fixture_path = File.expand_path(File.join(__FILE__, '..', 'fixtures'))
 
+module PuppetSpec
+  FIXTURE_DIR = File.join(dir = File.expand_path(File.dirname(__FILE__)), "fixtures") unless defined?(FIXTURE_DIR)
+end
+
 RSpec.configure do |c|
   c.module_path = File.join(fixture_path, 'modules')
   c.manifest_dir = File.join(fixture_path, 'manifests')

--- a/spec/unit/puppet_x/dell_powerconnect/dsl_spec.rb
+++ b/spec/unit/puppet_x/dell_powerconnect/dsl_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require 'puppet_x/dell_powerconnect/dsl'
+
+describe PuppetX::DellPowerconnect::Dsl do
+  let(:fact_fixtures) {File.join(PuppetSpec::FIXTURE_DIR,"unit","puppet_x","dell_powerconnect")}
+  let(:show_interface_status) { File.read(File.join(fact_fixtures, "show_interface_status.out"))}
+
+  describe "#vlan_information" do
+    it "should return the correct fact data" do
+      vlan_information = Class.new.extend(PuppetX::DellPowerconnect::Dsl).vlan_information(show_interface_status)
+      expect(vlan_information).to include("25")
+      expect(vlan_information["25"]).to eq({
+        "tagged_tengigabit" => "Te1/0/17,Te1/0/18,Te1/0/33",
+        "untagged_tengigabit" => "Te1/0/9,Te1/0/13,Te1/0/14,Te1/0/15,Te1/0/16,Te1/0/20,Te1/0/25,Te1/0/31,Te1/0/34,Te1/0/35,Te1/0/36,Te1/0/39",
+        "tagged_fortygigabit" => {},
+        "untagged_fortygigabit" => {},
+        "tagged_portchannel" => {},
+        "untagged_portchannel" => {}
+                                           })
+    end
+  end
+end


### PR DESCRIPTION
Added the vlan_information fact that matches the vlan_information
fact found in force10 devices.  This is an effort to normalize inventory
data across devices of various types

Fact example:
```json
{vlan_information"=>
  {"1"=>
    {"tagged_tengigabit"=>"Te1/0/1-4,Te1/0/7-16,Te1/0/19-38,Te1/0/40-47",
     "untagged_tengigabit"=>{},
     "tagged_fortygigabit"=>"Fo1/0/2",
     "untagged_fortygigabit"=>{},
     "tagged_portchannel"=>"Po1-128",
     "untagged_portchannel"=>{}},
   "16"=>
    {"tagged_tengigabit"=>{},
     "untagged_tengigabit"=>"Te1/0/2,Te1/0/5-6,Te1/0/33-36",
     "tagged_fortygigabit"=>{},
     "untagged_fortygigabit"=>{},
     "tagged_portchannel"=>{},
     "untagged_portchannel"=>"Po11-12,Po127"},
   "18"=>
    {"tagged_tengigabit"=>{}, "untagged_tengigabit"=>"Te1/0/2,Te1/0/29", "tagged_fortygigabit"=>{}, "untagged_fortygigabit"=>{}, "tagged_portchannel"=>{}, "untagged_portchannel"=>"Po11-12,Po126-127"}}}
```