### PR TITLE
added snmp community string command to get all community strings

### DIFF
--- a/lib/puppet_x/dell_powerconnect/possible_facts/base.rb
+++ b/lib/puppet_x/dell_powerconnect/possible_facts/base.rb
@@ -11,6 +11,14 @@ module PuppetX::DellPowerconnect::PossibleFacts::Base
       cmd 'show system'
     end
 
+    base.register_param 'snmp_community_string' do
+      match  do |txt|
+        item = txt.scan(/^(\w+)\s+\w+.\w+\s+\w+\s+\w+$/).flatten
+        item.to_json
+      end
+      cmd 'show snmp'
+    end
+
     base.register_param 'system_description' do
       match do |txt|
         txt.scan(/^System\s+Description:\s+(.+)$/).flatten.first

--- a/lib/puppet_x/dell_powerconnect/possible_facts/base.rb
+++ b/lib/puppet_x/dell_powerconnect/possible_facts/base.rb
@@ -19,6 +19,13 @@ module PuppetX::DellPowerconnect::PossibleFacts::Base
       cmd 'show snmp'
     end
 
+    base.register_param 'management_ip' do
+      match do |txt|
+        @transport.host
+      end
+      cmd 'show ip interface'
+    end
+
     base.register_param 'system_description' do
       match do |txt|
         txt.scan(/^System\s+Description:\s+(.+)$/).flatten.first


### PR DESCRIPTION
retrieves snmp community strings as an array. 

output:

"snmp_community_string":"[\"private\",\"public\",\"test\"]"