### PR TITLE
ASM 6091 Allow the untagged vlan id to  switchport configuration

### DIFF
--- a/lib/puppet_x/dell_powerconnect/model/interface/base.rb
+++ b/lib/puppet_x/dell_powerconnect/model/interface/base.rb
@@ -220,6 +220,7 @@ module PuppetX::DellPowerconnect::Model::Interface::Base
     Puppet.debug("Adding vlans #{untagged_vlan}")
     transport.command("interface #{interface_val[0]}/#{interface_val[1]}/#{interface_val[2]}")
     transport.command("switchport mode general")
+    transport.command("switchport general allowed vlan add #{untagged_vlan}")
     transport.command("switchport general pvid #{untagged_vlan}")
 
     transport.command("show running-config interface #{interface_val[0]}/#{interface_val[1]}/#{interface_val[2]}")

--- a/spec/unit/puppet_x/dell_powerconnect/model/interface/base_spec.rb
+++ b/spec/unit/puppet_x/dell_powerconnect/model/interface/base_spec.rb
@@ -74,6 +74,7 @@ describe PuppetX::DellPowerconnect::Model::Interface::Base do
     it "should add untagged vlans" do
       expect(transport).to receive(:command).with("interface Te1/0/29").ordered
       expect(transport).to receive(:command).with("switchport mode general").ordered
+      expect(transport).to receive(:command).with("switchport general allowed vlan add 29").ordered
       expect(transport).to receive(:command).with("switchport general pvid 29").ordered
       expect(transport).to receive(:command).with("show running-config interface Te1/0/29").ordered
       base.update_untagged_vlans(transport, [[], []], ["Te1", 0, 29], "29")
@@ -87,6 +88,7 @@ describe PuppetX::DellPowerconnect::Model::Interface::Base do
     it "should set untagged vlans" do
       expect(transport).to receive(:command).with("interface Te1/0/29").ordered
       expect(transport).to receive(:command).with("switchport mode general").ordered
+      expect(transport).to receive(:command).with("switchport general allowed vlan add 29").ordered
       expect(transport).to receive(:command).with("switchport general pvid 29").ordered
       expect(transport).to receive(:command).with("show running-config interface Te1/0/29").ordered
       base.update_untagged_vlans(transport, [[], [30]], ["Te1", 0, 29], "29")


### PR DESCRIPTION
Changes made to allow the untagged vlan id on switchport. Before switch port will allow untagged vlan when its fixed but When untagged vlan id was changed then It will not allow that in interface port channel. 
To resolve this code changes has been made. 