### PR TITLE
ASM 6091 updated switchport allowed vlan traffic

### DIFF
--- a/spec/fixtures/show_interfaces_switchport/vlan_multi_untagged_traffic.out
+++ b/spec/fixtures/show_interfaces_switchport/vlan_multi_untagged_traffic.out
@@ -1,0 +1,9 @@
+datacenter-bridging
+priority-flow-control mode on
+priority-flow-control priority 4 no-drop
+exit
+spanning-tree portfast
+switchport mode general
+switchport general pvid 29
+switchport general allowed vlan add 29,30
+switchport general allowed vlan add 20 tagged

--- a/spec/fixtures/show_interfaces_switchport/vlan_nountagged_traffic.out
+++ b/spec/fixtures/show_interfaces_switchport/vlan_nountagged_traffic.out
@@ -1,0 +1,7 @@
+datacenter-bridging
+priority-flow-control mode on
+priority-flow-control priority 4 no-drop
+exit
+spanning-tree portfast
+switchport mode general
+switchport general allowed vlan add 20 tagged

--- a/spec/fixtures/show_interfaces_switchport/vlan_untagged_traffic.out
+++ b/spec/fixtures/show_interfaces_switchport/vlan_untagged_traffic.out
@@ -1,0 +1,10 @@
+datacenter-bridging
+priority-flow-control mode on
+priority-flow-control priority 4 no-drop
+exit
+spanning-tree portfast
+switchport mode general
+switchport general pvid 29
+switchport general allowed vlan add 29
+switchport general allowed vlan add 20 tagged
+

--- a/spec/fixtures/show_interfaces_switchport/vlan_update_untagged_traffic.out
+++ b/spec/fixtures/show_interfaces_switchport/vlan_update_untagged_traffic.out
@@ -1,0 +1,9 @@
+datacenter-bridging
+priority-flow-control mode on
+priority-flow-control priority 4 no-drop
+exit
+spanning-tree portfast
+switchport mode general
+switchport general pvid 29
+switchport general allowed vlan add 30
+switchport general allowed vlan add 20 tagged


### PR DESCRIPTION
ASM should allow untagged vlan id to switchport traffic but when service tear down,should not allow untagged vlan id to switch port traffic.

code changes made will fix this issue. 