### PR TITLE
ASM-6742 Switch Resource Name is missing

### DIFF
--- a/lib/puppet_x/dell_powerconnect/possible_facts/base.rb
+++ b/lib/puppet_x/dell_powerconnect/possible_facts/base.rb
@@ -59,8 +59,8 @@ module PuppetX::DellPowerconnect::PossibleFacts::Base
     end
 
     base.register_param 'hostname' do
-      match /^hostname\s+(\S+)$/
-      cmd 'show running-config | grep hostname'
+      match /^System Name:\s+(\S+)$/
+      cmd 'show system | include "System Name"'
     end
 
     base.register_param 'defaultdomain' do


### PR DESCRIPTION
Fix the puppet fact collection to correctly get the hostname